### PR TITLE
Create git hooks to standardize commit and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# Initialize the repo.
+# Create git hooks to standardize commit and code
+
+Three git hooks, namely **pre-commit**, **commit-msg**, **pre-push** are
+created to standardize the commit and code in this repo.
+
+**pre-commit**: This hook is run before every commit is created. It stops
+developers from creating commits in the master/main branch directly. Besides,
+it also checks if the Python code is formatted properly with black, which
+formats Python code according to PEP8.
+
+**commit-msg**: This hook checks the commit message entered by the author.
+If the exit status is 0, the commit message will be aborted. In this
+repo, the exit status of this hook is always 0, even if there are
+errors or warnings. The purpose is to keep the commit message the author
+has entered and not discard it due to style issues. The author can modify the
+commit message according to the hints of this hook.
+
+**pre-push**: This hook is run before commits are pushed to the remote
+repository. It stops developers pushing to the master/main branch directly.
+Besides, it also does unit tests. If the unit tests fail, the push will be
+aborted.

--- a/git-hooks/copy_hooks.sh
+++ b/git-hooks/copy_hooks.sh
@@ -1,0 +1,5 @@
+#/bin/bash
+
+repo_dir=$(git rev-parse --show-toplevel)
+cp $repo_dir/git-hooks/hooks/* $repo_dir/.git/hooks
+chmod +x $repo_dir/.git/hooks/*

--- a/git-hooks/hooks/commit-msg
+++ b/git-hooks/hooks/commit-msg
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+import sys
+from enum import Enum
+
+# https://stackoverflow.com/questions/287871/how-to-print-colored-text-to-the-terminal
+class bcolors(str, Enum):
+    OK = "\033[92m"
+    INFO = "\033[94m"
+    WARNING = "\033[93m"
+    ERROR = "\033[91m"
+    BOLD = "\033[1m"
+    ENDC = "\033[0m"
+
+
+class Level(str, Enum):
+    OK = "OK"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+
+
+def print_with_color(message: str, level: Level):
+    print(
+        bcolors[level]
+        + bcolors.BOLD
+        + f"{level}: [Policy] "
+        + message
+        + bcolors.ENDC
+    )
+
+
+def check_commit_msg_pattern():
+    # The argument passed to the "commit-msg" hook is the path to a
+    # temporary file that contains the commit message written by the
+    # developer.
+    msg_temp_file = sys.argv[1]
+
+    with open(msg_temp_file, "r") as f_msg:
+        lines = f_msg.readlines()
+
+    # Remove the comment lines in the commit message.
+    lines = [l for l in lines if not l.strip().startswith("#")]
+
+    has_warning = False
+    if len(lines) < 3:
+        message = "There should at least three lines in your commit message."
+        print_with_color(message, Level.ERROR)
+        exit()
+
+    if len(lines[0]) > 50:
+        has_warning = True
+        message = (
+            "There should be less then 50 characters in the commit title."
+        )
+
+        print_with_color(message, Level.WARNING)
+
+    if lines[1].strip() != "":
+        has_warning = True
+        message = (
+            "There should be an empty line between the commit title and body."
+        )
+        print_with_color(message, Level.WARNING)
+
+    for line in lines[2:]:
+        if len(line) > 72:
+            has_warning = True
+            message = "The commit body should wrap at 72 characters."
+            print_with_color(message, Level.WARNING)
+
+    if not has_warning:
+        message = "The commit message has the required pattern."
+        print_with_color(message, Level.OK)
+
+
+if __name__ == "__main__":
+    check_commit_msg_pattern()

--- a/git-hooks/hooks/pre-commit
+++ b/git-hooks/hooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+current_branch=`git rev-parse --abbrev-ref HEAD`
+if [[ $current_branch =~ master|main ]]; then
+    message="Please don't commit directly to $current_branch."
+    echo -e "\033[1;31mERROR: $message\033[0m";
+    exit 1
+fi
+
+repo_dir=`git rev-parse --show-toplevel`
+
+message="[Policy] Checking code in $repo_dir with black..."
+# echo with color: https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797
+echo -e "\033[1;34mInfo: $message\033[0m"
+
+black -t py38 --check $repo_dir
+
+if [ $? -eq 1 ]; then
+    message="[Policy] Black check failed, please use black to format your code."
+    echo -e "\033[1;31mERROR: $message\033[0m";
+    exit 1
+else
+    message="[Policy] Passed black checking."
+    echo -e "\033[1;32mOK: $message\033[0m"
+    exit 0
+fi

--- a/git-hooks/hooks/pre-push
+++ b/git-hooks/hooks/pre-push
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+current_branch=`git rev-parse --abbrev-ref HEAD`
+if [[ $current_branch =~ master|main ]]; then
+    message="Please don't push directly to $current_branch."
+    echo -e "\033[1;31mERROR: $message\033[0m";
+    exit 1
+fi
+
+repo_dir=`git rev-parse --show-toplevel`
+
+message="[Policy] Doing unit tests ..."
+echo -e "\033[1;34mInfo: $message\033[0m"
+
+pytest $repo_dir/test.py
+
+if [ $? -eq 1 ]; then
+    message="[Policy] Unit tests failed, please check and fix your code."
+    echo -e "\033[1;31mERROR: $message\033[0m";
+    exit 1
+else
+    message="[Policy] Passed unit tests."
+    echo -e "\033[1;32mOK: $message\033[0m"
+    exit 0
+fi


### PR DESCRIPTION
Three git hooks, namely "pre-commit", "commit-msg", "pre-push" are
created to standardize the commit and code in this repo.

pre-commit: This hook is run before every commit is created. It stops
developers from creating commits in the master branch. Besides, it
also checks if the Python code is formatted properly with black, which
formats Python code according to PEP8.

commit-msg: This hook checks the commit message entered by the author.
If the exit status is 0, the commit message will be aborted. In this
repo, the exit status of this hook is always 0, even if there are
errors or warnings. The purpose is to keep what the author has entered
and not discard it due to style issues. The author can modify the
commit message according to the hints of this hook.

pre-push: This hook is run before commits are pushed to the remote
repository. It stops developers pushing to the master branch. Besides,
it also does unit tests. If the unit tests fail, the push will be
aborted.